### PR TITLE
Fix publish checkbox interaction and preserve form scroll

### DIFF
--- a/app/manage/content/edit/[id]/EditContentForm.tsx
+++ b/app/manage/content/edit/[id]/EditContentForm.tsx
@@ -585,12 +585,13 @@ export function EditContentForm({
                   <FormItem className="flex flex-row items-start space-x-3 space-y-0">
                     <FormControl>
                       <Checkbox
+                        id="published"
                         checked={field.value}
                         onCheckedChange={field.onChange}
                       />
                     </FormControl>
                     <div className="space-y-1 leading-none">
-                      <FormLabel>
+                      <FormLabel htmlFor="published">
                         Published
                       </FormLabel>
                       <FormDescription>

--- a/app/manage/content/new/NewContentEditor.tsx
+++ b/app/manage/content/new/NewContentEditor.tsx
@@ -556,12 +556,13 @@ export function NewContentEditor({
                   <FormItem className="flex flex-row items-start space-x-3 space-y-0">
                     <FormControl>
                       <Checkbox
+                        id="published"
                         checked={field.value}
                         onCheckedChange={field.onChange}
                       />
                     </FormControl>
                     <div className="space-y-1 leading-none">
-                      <FormLabel>
+                      <FormLabel htmlFor="published">
                         Publish immediately
                       </FormLabel>
                       <FormDescription>

--- a/app/manage/content/new/NewContentManagementPage.tsx
+++ b/app/manage/content/new/NewContentManagementPage.tsx
@@ -65,6 +65,7 @@ export function NewContentManagementPage({
   
   // Handle file change
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const scrollPosition = window.scrollY
     const file = e.target.files?.[0]
     if (file) {
       // Validate file size (max 5MB)
@@ -76,7 +77,7 @@ export function NewContentManagementPage({
         })
         return
       }
-      
+
       // Validate file type
       if (!file.type.startsWith('image/')) {
         toast({
@@ -86,9 +87,12 @@ export function NewContentManagementPage({
         })
         return
       }
-      
+
       setFile(file)
       setPreviewUrl(URL.createObjectURL(file))
+
+      // Restore scroll position after thumbnail preview causes layout shift
+      requestAnimationFrame(() => window.scrollTo(0, scrollPosition))
     }
   }
   

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
+      "peer h-4 w-4 shrink-0 rounded-sm border border-primary shadow cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- make publish checkbox clickable in new and edit content forms
- keep scroll position after thumbnail upload to prevent jumping
- add cursor pointer to checkbox component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68999a21a15c832ab4f3b35d847edf3b