### PR TITLE
feat(editor): clear placeholder on edit

### DIFF
--- a/app/manage/content/editor/[id]/ContentEditor.tsx
+++ b/app/manage/content/editor/[id]/ContentEditor.tsx
@@ -53,10 +53,14 @@ export function ContentEditor({ contentId, initialContent }: ContentEditorProps)
   useEffect(() => {
     // Process the initial content - handle different formats
     let processedContent = initialContent
-    
-    // If the content is empty, start with something
-    if (!initialContent || initialContent === '') {
-      processedContent = '<p>Start editing your content here...</p>'
+
+    // If the content is empty or just the placeholder, start with an empty string
+    if (
+      !initialContent ||
+      initialContent === '' ||
+      initialContent.trim() === '<p>Start editing your content here...</p>'
+    ) {
+      processedContent = ''
     } else {
       // Try to see if it's JSON format
       try {

--- a/components/editor/editor-wrapper.tsx
+++ b/components/editor/editor-wrapper.tsx
@@ -210,7 +210,7 @@ export function Editor({ onChange, initialData = '', readOnly = false, onFocus, 
         codeBlock: false,
       }),
       Placeholder.configure({
-        placeholder: 'Start typing or paste content here...',
+        placeholder: 'Start editing your content here...',
         showOnlyWhenEditable: true,
       }),
       Link.configure({


### PR DESCRIPTION
## Summary
- prevent placeholder text from being inserted into editor content
- show editor placeholder via Tiptap placeholder extension

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68999a15142c832aa063295667265a8e