### PR TITLE
fix: persist admin role after session refresh

### DIFF
--- a/hooks/useAuth.tsx
+++ b/hooks/useAuth.tsx
@@ -144,7 +144,7 @@ export function AuthProvider({
     }
 
     deriveRoleFromTier()
-  }, [supabase, session?.user?.id])
+  }, [supabase, session])
 
   // Sign up the user
   const signUp = async (email: string, password: string, metadata?: object) => {


### PR DESCRIPTION
## Summary
- ensure admin role is restored whenever session updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a28d49368832a8825ce3e448467d2