### PR TITLE
Add desktop search bar and mobile search icon

### DIFF
--- a/app/(main)/home-client-content.tsx
+++ b/app/(main)/home-client-content.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useCallback, useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import { toast } from '@/hooks/use-toast'
 import { ContentLayout } from '@/components/content/content-layout'
 import { useContent } from '@/lib/hooks/useContent'
@@ -27,7 +27,8 @@ export function HomeClientContent({
   ageGroups?: any[],
   categories?: any[]
 }) {
-  const router = useRouter()
+  const searchParams = useSearchParams()
+  const searchQuery = searchParams.get('search') || ''
   const { user } = useAuth()
   const isAuthenticated = !!user
   const { canAccessPremiumContent, isAdmin } = useAuthorization()
@@ -38,8 +39,6 @@ export function HomeClientContent({
   
   // Add safety checks
   const hasContent = Array.isArray(initialContent) && initialContent.length > 0
-  const hasFilters = (Array.isArray(ageGroups) && ageGroups.length > 0) || 
-                    (Array.isArray(categories) && categories.length > 0)
 
   // If we have no content, show a message
   if (!hasContent) {
@@ -62,6 +61,7 @@ export function HomeClientContent({
   } = useContent({
     ageGroups: selectedAgeGroups.length > 0 ? selectedAgeGroups : undefined,
     categories: selectedCategories.length > 0 ? selectedCategories : undefined,
+    searchQuery: searchQuery || undefined,
     showPremiumOnly,
     initialLoad: false // Don't load on initial render, we already have initialContent
   })
@@ -73,11 +73,15 @@ export function HomeClientContent({
   useEffect(() => {
     if (content && content.length > 0) {
       setDisplayContent(content)
-    } else if (content && content.length === 0 && (selectedAgeGroups.length > 0 || selectedCategories.length > 0)) {
-      // If we have filters applied and no content was found, show empty array
+    } else if (
+      content &&
+      content.length === 0 &&
+      (selectedAgeGroups.length > 0 || selectedCategories.length > 0 || searchQuery)
+    ) {
+      // If we have filters applied or search query and no content was found, show empty array
       setDisplayContent([])
     }
-  }, [content, selectedAgeGroups.length, selectedCategories.length])
+  }, [content, selectedAgeGroups.length, selectedCategories.length, searchQuery])
   
   // Handle age group selection
   const handleAgeGroupSelect = useCallback((id: string) => {
@@ -119,7 +123,7 @@ export function HomeClientContent({
   // Trigger content refresh when filters change
   useEffect(() => {
     refresh()
-  }, [selectedAgeGroups, selectedCategories, refresh])
+  }, [selectedAgeGroups, selectedCategories, searchQuery, refresh])
   
   // Handle errors
   useEffect(() => {

--- a/components/ui/navigation.tsx
+++ b/components/ui/navigation.tsx
@@ -7,6 +7,9 @@ import { Logo } from '@/components/ui/logo'
 import { Button } from '@/components/ui/button'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthorization } from '@/hooks/useAuthorization'
+import SearchBar from '@/components/ui/search-bar'
+import { Sheet, SheetTrigger, SheetContent } from '@/components/ui/sheet'
+import { Search } from 'lucide-react'
  
 
 export function Navigation() {
@@ -14,6 +17,7 @@ export function Navigation() {
   const { isPremium, isAdmin } = useAuthorization()
   const pathname = usePathname()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const [isSearchOpen, setIsSearchOpen] = useState(false)
 
   const handleSignOut = async () => {
     await signOut()
@@ -41,7 +45,7 @@ export function Navigation() {
   return (
     <header className="bg-white border-b border-gray-200 sticky top-0 z-50">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between items-center h-16">
+        <div className="flex items-center h-16">
           {/* Logo and main navigation */}
           <div className="flex items-center">
             <div className="flex-shrink-0">
@@ -85,8 +89,13 @@ export function Navigation() {
             </nav>
           </div>
 
+          {/* Desktop search */}
+          <div className="hidden md:flex flex-1 justify-center px-4">
+            <SearchBar />
+          </div>
+
           {/* Authentication buttons */}
-          <div className="hidden md:flex items-center space-x-4">
+          <div className="hidden md:flex items-center space-x-4 ml-auto">
             {isAuthenticated ? (
               <div className="flex items-center space-x-4">
                 {isPremium() && (
@@ -152,8 +161,19 @@ export function Navigation() {
             )}
           </div>
 
-          {/* Mobile menu button */}
-          <div className="md:hidden flex items-center">
+          {/* Mobile actions */}
+          <div className="md:hidden flex items-center ml-auto space-x-2">
+            <Sheet open={isSearchOpen} onOpenChange={setIsSearchOpen}>
+              <SheetTrigger asChild>
+                <button className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-secondary-navy">
+                  <Search className="h-6 w-6" />
+                  <span className="sr-only">Ieškoti</span>
+                </button>
+              </SheetTrigger>
+              <SheetContent side="top" className="p-4">
+                <SearchBar onSearch={() => setIsSearchOpen(false)} />
+              </SheetContent>
+            </Sheet>
             <button
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-secondary-navy"

--- a/components/ui/search-bar.tsx
+++ b/components/ui/search-bar.tsx
@@ -45,4 +45,3 @@ export function SearchBar({ className, onSearch }: SearchBarProps) {
 }
 
 export default SearchBar
-

--- a/components/ui/search-bar.tsx
+++ b/components/ui/search-bar.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Search } from 'lucide-react'
+import { cn } from '@/lib/utils/index'
+
+interface SearchBarProps {
+  className?: string
+  onSearch?: () => void
+}
+
+export function SearchBar({ className, onSearch }: SearchBarProps) {
+  const [query, setQuery] = useState('')
+  const router = useRouter()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const trimmed = query.trim()
+    if (trimmed) {
+      router.push(`/?search=${encodeURIComponent(trimmed)}`)
+    } else {
+      router.push('/')
+    }
+    onSearch?.()
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className={cn('flex items-center w-full', className)}>
+      <Input
+        type="search"
+        placeholder="Ieškoti..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        className="h-9 flex-1"
+      />
+      <Button type="submit" size="icon" variant="outline" className="ml-2 h-9 w-9">
+        <Search className="h-4 w-4" />
+        <span className="sr-only">Ieškoti</span>
+      </Button>
+    </form>
+  )
+}
+
+export default SearchBar
+


### PR DESCRIPTION
## Summary
- add reusable `SearchBar` component for content lookup
- integrate search UI into navigation on desktop and mobile
- filter home page content by URL `search` query

## Testing
- `npm test`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689a32224360832a81e9bd1c4fabe8d4