### PR TITLE
feat: improve mobile card layout

### DIFF
--- a/components/content/content-grid.tsx
+++ b/components/content/content-grid.tsx
@@ -78,11 +78,11 @@ export function ContentGrid({
         {isLoading ? (
           <ContentSkeleton count={6} />
         ) : filteredForDisplay.length > 0 ? (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
             {filteredForDisplay.map((item, index) => (
-              <ContentCard 
-                key={item.id} 
-                content={item} 
+              <ContentCard
+                key={item.id}
+                content={item}
                 index={index}
                 isPremiumLocked={item.access_tier?.name === 'premium' && (!isAuthenticated || !canAccessPremiumContent())}
                 showEditButton={showEditButtons}

--- a/components/ui/content-card.tsx
+++ b/components/ui/content-card.tsx
@@ -80,10 +80,10 @@ export function ContentCard({
             </div>
           )}
         </div>
-        <CardContent className="p-4 flex-grow">
-          <h3 className="text-lg font-semibold mb-2">{content.title}</h3>
+        <CardContent className="p-3 sm:p-4 flex-grow">
+          <h3 className="text-base sm:text-lg font-semibold mb-2">{content.title}</h3>
           {showDescription && content.description && (
-            <p className="text-gray-600 text-sm line-clamp-2">
+            <p className="text-gray-600 text-xs sm:text-sm line-clamp-2">
               {content.description}
             </p>
           )}
@@ -95,7 +95,7 @@ export function ContentCard({
         </CardContent>
       </div>
       
-      <CardFooter className="px-4 py-3 bg-gray-50 flex justify-between" onClick={e => e.stopPropagation()}>
+      <CardFooter className="px-3 py-2 sm:px-4 sm:py-3 bg-gray-50 flex justify-between" onClick={e => e.stopPropagation()}>
         <div className="flex items-center gap-2">
           <ContentTypeBadge type={content.type} variant="outline" />
         </div>


### PR DESCRIPTION
## Summary
- use a denser responsive grid for content cards
- shrink card padding and text on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a31830e78832aaf06a5267e0ed013