### PR TITLE
Embed videos and remove placeholder after load

### DIFF
--- a/components/content/content-detail-media.tsx
+++ b/components/content/content-detail-media.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
+import { useState } from 'react'
 import type { ContentItem } from '@/lib/types/database'
 
 interface ContentDetailMediaProps {
@@ -15,13 +15,38 @@ interface ContentDetailMediaProps {
  * - Audio player for audio content
  */
 export function ContentDetailMedia({ content }: ContentDetailMediaProps) {
+  const [videoLoaded, setVideoLoaded] = useState(false)
+  const videoUrl = content.metadata?.mediaUrl || content.metadata?.embed_links?.[0]
+
+  const getEmbedUrl = (url: string) => {
+    if (!url) return ''
+    const ytMatch = url.match(/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/|shorts\/))([\w-]{11})/i)
+    if (ytMatch) {
+      return `https://www.youtube.com/embed/${ytMatch[1]}`
+    }
+    const vimeoMatch = url.match(/vimeo\.com\/(?:video\/)?(\d+)/)
+    if (vimeoMatch) {
+      return `https://player.vimeo.com/video/${vimeoMatch[1]}`
+    }
+    return url
+  }
+
   return (
     <div className="bg-white rounded-lg shadow-md p-6 mb-8">
-      {content.type === 'video' && (
+      {content.type === 'video' && videoUrl && (
         <div className="aspect-w-16 aspect-h-9 mb-4">
-          <div className="flex items-center justify-center h-full bg-gray-100 rounded-lg">
-            <p className="text-gray-500">Video content will be displayed here</p>
-          </div>
+          {!videoLoaded && (
+            <div className="flex items-center justify-center h-full bg-gray-100 rounded-lg">
+              <p className="text-gray-500">Video content will be displayed here</p>
+            </div>
+          )}
+          <iframe
+            src={getEmbedUrl(videoUrl)}
+            className={`w-full h-full rounded-lg ${videoLoaded ? '' : 'hidden'}`}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            onLoad={() => setVideoLoaded(true)}
+          />
         </div>
       )}
 

--- a/components/content/content-detail-media.tsx
+++ b/components/content/content-detail-media.tsx
@@ -1,7 +1,7 @@
 'use client'
 
-import { useState } from 'react'
 import type { ContentItem } from '@/lib/types/database'
+import { useVideoEmbed } from '@/lib/hooks/useVideoEmbed'
 
 interface ContentDetailMediaProps {
   content: ContentItem
@@ -15,21 +15,8 @@ interface ContentDetailMediaProps {
  * - Audio player for audio content
  */
 export function ContentDetailMedia({ content }: ContentDetailMediaProps) {
-  const [videoLoaded, setVideoLoaded] = useState(false)
   const videoUrl = content.metadata?.mediaUrl || content.metadata?.embed_links?.[0]
-
-  const getEmbedUrl = (url: string) => {
-    if (!url) return ''
-    const ytMatch = url.match(/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/|shorts\/))([\w-]{11})/i)
-    if (ytMatch) {
-      return `https://www.youtube.com/embed/${ytMatch[1]}`
-    }
-    const vimeoMatch = url.match(/vimeo\.com\/(?:video\/)?(\d+)/)
-    if (vimeoMatch) {
-      return `https://player.vimeo.com/video/${vimeoMatch[1]}`
-    }
-    return url
-  }
+  const { embedUrl, videoLoaded, handleLoad } = useVideoEmbed(videoUrl)
 
   return (
     <div className="bg-white rounded-lg shadow-md p-6 mb-8">
@@ -41,11 +28,11 @@ export function ContentDetailMedia({ content }: ContentDetailMediaProps) {
             </div>
           )}
           <iframe
-            src={getEmbedUrl(videoUrl)}
+            src={embedUrl}
             className={`w-full h-full rounded-lg ${videoLoaded ? '' : 'hidden'}`}
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
-            onLoad={() => setVideoLoaded(true)}
+            onLoad={handleLoad}
           />
         </div>
       )}

--- a/components/content/content-detail.tsx
+++ b/components/content/content-detail.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { getFeedback, addFeedback } from '@/lib/services/content'
 import type { ContentItem } from '@/lib/types/database'
@@ -19,6 +18,7 @@ import { cn } from '@/lib/utils/index'
 import { validateStorageUrl } from '@/lib/utils/index'
 import { useAuth } from '@/hooks/useAuth'
 import { useAuthorization } from '@/hooks/useAuthorization'
+import { useVideoEmbed } from '@/lib/hooks/useVideoEmbed'
 import {
   Tooltip,
   TooltipContent,
@@ -64,21 +64,8 @@ export function ContentDetail({ content }: ContentDetailProps) {
 
   const canEdit = isAdmin();
 
-  const [videoLoaded, setVideoLoaded] = useState(false)
   const videoUrl = content?.metadata?.mediaUrl || content?.metadata?.embed_links?.[0]
-
-  const getEmbedUrl = (url: string) => {
-    if (!url) return ''
-    const ytMatch = url.match(/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/|shorts\/))([\w-]{11})/i)
-    if (ytMatch) {
-      return `https://www.youtube.com/embed/${ytMatch[1]}`
-    }
-    const vimeoMatch = url.match(/vimeo\.com\/(?:video\/)?(\d+)/)
-    if (vimeoMatch) {
-      return `https://player.vimeo.com/video/${vimeoMatch[1]}`
-    }
-    return url
-  }
+  const { embedUrl, videoLoaded, handleLoad } = useVideoEmbed(videoUrl)
 
   if (!content) {
     return (
@@ -266,11 +253,11 @@ export function ContentDetail({ content }: ContentDetailProps) {
                 </div>
               )}
               <iframe
-                src={getEmbedUrl(videoUrl)}
+                src={embedUrl}
                 className={`w-full h-full rounded-lg ${videoLoaded ? '' : 'hidden'}`}
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                 allowFullScreen
-                onLoad={() => setVideoLoaded(true)}
+                onLoad={handleLoad}
               />
             </div>
           )}

--- a/components/content/content-detail.tsx
+++ b/components/content/content-detail.tsx
@@ -27,7 +27,6 @@ import {
 } from "@/components/ui/tooltip"
 import { ContentDetailHeader } from './content-detail-header'
 import { ContentDetailMetadata } from './content-detail-metadata'
-import { ContentDetailMedia } from './content-detail-media'
 import { ContentDetailBody } from './content-detail-body'
 import { ContentDetailFeedback } from './content-detail-feedback'
 import { SimpleContentDetailAttachments } from './simple-content-detail-attachments'
@@ -64,6 +63,22 @@ export function ContentDetail({ content }: ContentDetailProps) {
   const isPremiumLocked = isPremium && (!isAuthenticated || !canAccessPremiumContent());
 
   const canEdit = isAdmin();
+
+  const [videoLoaded, setVideoLoaded] = useState(false)
+  const videoUrl = content?.metadata?.mediaUrl || content?.metadata?.embed_links?.[0]
+
+  const getEmbedUrl = (url: string) => {
+    if (!url) return ''
+    const ytMatch = url.match(/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/|shorts\/))([\w-]{11})/i)
+    if (ytMatch) {
+      return `https://www.youtube.com/embed/${ytMatch[1]}`
+    }
+    const vimeoMatch = url.match(/vimeo\.com\/(?:video\/)?(\d+)/)
+    if (vimeoMatch) {
+      return `https://player.vimeo.com/video/${vimeoMatch[1]}`
+    }
+    return url
+  }
 
   if (!content) {
     return (
@@ -243,11 +258,20 @@ export function ContentDetail({ content }: ContentDetailProps) {
           </div>
 
           {/* Video Content */}
-          {content.type === 'video' && (
+          {content.type === 'video' && videoUrl && (
             <div className="aspect-w-16 aspect-h-9">
-              <div className="flex items-center justify-center h-full bg-gray-100 rounded-lg">
-                <p className="text-gray-500">Video content will be displayed here</p>
-              </div>
+              {!videoLoaded && (
+                <div className="flex items-center justify-center h-full bg-gray-100 rounded-lg">
+                  <p className="text-gray-500">Video content will be displayed here</p>
+                </div>
+              )}
+              <iframe
+                src={getEmbedUrl(videoUrl)}
+                className={`w-full h-full rounded-lg ${videoLoaded ? '' : 'hidden'}`}
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+                onLoad={() => setVideoLoaded(true)}
+              />
             </div>
           )}
 

--- a/lib/hooks/useVideoEmbed.ts
+++ b/lib/hooks/useVideoEmbed.ts
@@ -1,0 +1,12 @@
+import { useState, useMemo, useCallback } from 'react'
+import { getEmbedUrl } from '@/lib/utils/get-embed-url'
+
+export function useVideoEmbed(videoUrl?: string) {
+  const [videoLoaded, setVideoLoaded] = useState(false)
+
+  const embedUrl = useMemo(() => getEmbedUrl(videoUrl || ''), [videoUrl])
+
+  const handleLoad = useCallback(() => setVideoLoaded(true), [])
+
+  return { embedUrl, videoLoaded, handleLoad }
+}

--- a/lib/utils/get-embed-url.ts
+++ b/lib/utils/get-embed-url.ts
@@ -1,0 +1,12 @@
+export function getEmbedUrl(url: string) {
+  if (!url) return ''
+  const ytMatch = url.match(/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/|shorts\/))([\w-]{11})/i)
+  if (ytMatch) {
+    return `https://www.youtube.com/embed/${ytMatch[1]}`
+  }
+  const vimeoMatch = url.match(/vimeo\.com\/(?:video\/)?(\d+)/)
+  if (vimeoMatch) {
+    return `https://player.vimeo.com/video/${vimeoMatch[1]}`
+  }
+  return url
+}


### PR DESCRIPTION
## Summary
- Convert media URLs to YouTube/Vimeo embeds and hide placeholder once loaded
- Remove raw video URLs and placeholder from content detail components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a31668e20832a8a3ba804ad5f3150