### PR TITLE
Improve mobile layout for homepage

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -62,7 +62,7 @@ export default async function RootLayout({
   
   return (
     <html lang="en" suppressHydrationWarning className="h-full">
-      <body className={cn(inter.className, "flex flex-col h-full")}>
+      <body className={cn(inter.className, "flex flex-col min-h-screen overflow-x-hidden")}>
         <Providers session={serializedSession}>
           <Navigation />
           <main className="flex-1">

--- a/components/content/content-grid.tsx
+++ b/components/content/content-grid.tsx
@@ -78,7 +78,7 @@ export function ContentGrid({
         {isLoading ? (
           <ContentSkeleton count={6} />
         ) : filteredForDisplay.length > 0 ? (
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 sm:gap-6">
             {filteredForDisplay.map((item, index) => (
               <ContentCard
                 key={item.id}


### PR DESCRIPTION
## Summary
- Prevent horizontal scrolling on mobile by hiding x-overflow on body
- Use single-column content grid on small screens for better mobile layout

## Testing
- `npm test`
- `npm run lint` *(fails: prompts to configure ESLint)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a4c474d80c832aafd9ef42d6511e44