### PR TITLE
Translate user-facing text to Lithuanian

### DIFF
--- a/app/(main)/home-client-content.tsx
+++ b/app/(main)/home-client-content.tsx
@@ -65,9 +65,9 @@ export function HomeClientContent({
   if (!hasContent) {
     return (
       <div className="p-8 text-center">
-        <h2 className="text-2xl font-bold mb-4">No content available</h2>
+        <h2 className="text-2xl font-bold mb-4">Turinio nėra</h2>
         <p className="text-gray-600">
-          There is currently no content available to display. Please check back later.
+          Šiuo metu nėra turinio. Prašome užsukti vėliau.
         </p>
       </div>
     )
@@ -176,11 +176,11 @@ export function HomeClientContent({
         <div className="mb-4 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
           <div className="flex justify-between items-center">
             <div>
-              <h3 className="font-medium text-yellow-800">Admin Mode</h3>
-              <p className="text-sm text-yellow-600">You can edit content directly from this page.</p>
+              <h3 className="font-medium text-yellow-800">Administratoriaus režimas</h3>
+              <p className="text-sm text-yellow-600">Galite redaguoti turinį tiesiogiai šiame puslapyje.</p>
             </div>
             <Link href="/manage/content/new">
-              <Button>Create New Content</Button>
+              <Button>Kurti naują turinį</Button>
             </Link>
           </div>
         </div>

--- a/app/(main)/page.tsx
+++ b/app/(main)/page.tsx
@@ -38,7 +38,7 @@ export default function HomePage() {
         const response = await fetch('/api/content');
         
         if (!response.ok) {
-          throw new Error('Failed to fetch content data');
+          throw new Error('Nepavyko gauti turinio duomenų');
         }
         
         const data = await response.json();
@@ -55,8 +55,8 @@ export default function HomePage() {
           ...prev,
           loading: false,
           error: {
-            message: error instanceof Error ? error.message : 'Unknown error occurred',
-            name: error instanceof Error ? error.name : 'Error'
+            message: error instanceof Error ? error.message : 'Įvyko nežinoma klaida',
+            name: error instanceof Error ? error.name : 'Klaida'
           }
         }));
       }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -2,8 +2,8 @@ import { Metadata } from 'next'
 import { SignInForm } from '@/components/auth/sign-in-form'
 
 export const metadata: Metadata = {
-  title: 'Login | Solis',
-  description: 'Login to your account',
+  title: 'Prisijungimas | Solis',
+  description: 'Prisijunkite prie savo paskyros',
 }
 
 export const dynamic = 'force-dynamic'
@@ -14,7 +14,7 @@ export default function LoginPage() {
       <div className="flex flex-col items-center justify-center min-h-[calc(100vh-8rem)]">
         <div className="mx-auto w-full max-w-md">
           <h1 className="text-2xl font-bold text-center mb-6">
-            Login to Your Account
+            Prisijunkite prie savo paskyros
           </h1>
           <SignInForm />
         </div>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -11,7 +11,7 @@ export default function ProfilePage() {
         <div className="flex flex-col items-center justify-center">
           <div className="mx-auto w-full max-w-3xl">
             <h1 className="text-2xl font-bold mb-6">
-              Your Profile
+              Jūsų profilis
             </h1>
             <ProfileForm />
           </div>

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -2,8 +2,8 @@ import { Metadata } from 'next'
 import { PasswordResetForm } from '@/components/auth/password-reset-form'
 
 export const metadata: Metadata = {
-  title: 'Reset Password | Solis',
-  description: 'Reset your password',
+  title: 'Atkurti slaptažodį | Solis',
+  description: 'Atkurkite savo slaptažodį',
 }
 
 export default function ResetPasswordPage() {
@@ -12,7 +12,7 @@ export default function ResetPasswordPage() {
       <div className="flex flex-col items-center justify-center min-h-[calc(100vh-8rem)]">
         <div className="mx-auto w-full max-w-md">
           <h1 className="text-2xl font-bold text-center mb-6">
-            Reset Your Password
+            Atkurkite savo slaptažodį
           </h1>
           <PasswordResetForm />
         </div>

--- a/app/update-password/page.tsx
+++ b/app/update-password/page.tsx
@@ -2,8 +2,8 @@ import { Metadata } from 'next'
 import { UpdatePasswordForm } from '@/components/auth/update-password-form'
 
 export const metadata: Metadata = {
-  title: 'Update Password | Solis',
-  description: 'Update your password',
+  title: 'Atnaujinti slaptažodį | Solis',
+  description: 'Atnaujinkite savo slaptažodį',
 }
 
 export default function UpdatePasswordPage() {
@@ -12,7 +12,7 @@ export default function UpdatePasswordPage() {
       <div className="flex flex-col items-center justify-center min-h-[calc(100vh-8rem)]">
         <div className="mx-auto w-full max-w-md">
           <h1 className="text-2xl font-bold text-center mb-6">
-            Update Your Password
+            Atnaujinkite savo slaptažodį
           </h1>
           <UpdatePasswordForm />
         </div>

--- a/components/auth/password-reset-form.tsx
+++ b/components/auth/password-reset-form.tsx
@@ -22,7 +22,7 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import Link from 'next/link'
 
 const formSchema = z.object({
-  email: z.string().email({ message: 'Please enter a valid email address.' }),
+  email: z.string().email({ message: 'Įveskite teisingą el. pašto adresą.' }),
 })
 
 type FormValues = z.infer<typeof formSchema>
@@ -45,13 +45,13 @@ export function PasswordResetForm() {
       await resetPassword(values.email)
       setIsSubmitted(true)
       toast({
-        title: 'Password reset email sent',
-        description: 'Please check your email for a link to reset your password.',
+        title: 'Slaptažodžio atstatymo laiškas išsiųstas',
+        description: 'Patikrinkite el. paštą, norėdami gauti slaptažodžio atstatymo nuorodą.',
       })
     } catch (error: any) {
       toast({
-        title: 'Error',
-        description: error.message || 'Failed to send reset password email. Please try again.',
+        title: 'Klaida',
+        description: error.message || 'Nepavyko išsiųsti slaptažodžio atstatymo laiško. Bandykite dar kartą.',
         variant: 'destructive',
       })
     } finally {
@@ -63,28 +63,28 @@ export function PasswordResetForm() {
     return (
       <Card className="w-full max-w-md mx-auto">
         <CardHeader>
-          <CardTitle>Check Your Email</CardTitle>
+          <CardTitle>Patikrinkite el. paštą</CardTitle>
           <CardDescription>
-            We&apos;ve sent a password reset link to your email address.
+            Išsiuntėme slaptažodžio atstatymo nuorodą į jūsų el. paštą.
           </CardDescription>
         </CardHeader>
         <CardContent className="text-center">
           <p>
-            Please check your email and follow the instructions to reset your password.
+            Patikrinkite el. paštą ir sekite instrukcijas slaptažodžiui atkurti.
           </p>
           <p className="mt-4">
-            Didn&apos;t receive an email?{' '}
+            Negavote laiško?{' '}
             <button
               onClick={() => setIsSubmitted(false)}
               className="text-primary hover:underline"
             >
-              Try again
+              Pabandykite dar kartą
             </button>
           </p>
         </CardContent>
         <CardFooter className="flex justify-center">
           <Link href="/login" className="text-primary hover:underline">
-            Back to login
+            Atgal į prisijungimą
           </Link>
         </CardFooter>
       </Card>
@@ -94,9 +94,9 @@ export function PasswordResetForm() {
   return (
     <Card className="w-full max-w-md mx-auto">
       <CardHeader>
-        <CardTitle>Reset Password</CardTitle>
+        <CardTitle>Atkurti slaptažodį</CardTitle>
         <CardDescription>
-          Enter your email address and we&apos;ll send you a link to reset your password.
+          Įveskite el. pašto adresą ir atsiųsime nuorodą slaptažodžiui atkurti.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -107,7 +107,7 @@ export function PasswordResetForm() {
               name="email"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Email</FormLabel>
+                  <FormLabel>El. paštas</FormLabel>
                   <FormControl>
                     <Input 
                       placeholder="email@example.com" 
@@ -125,19 +125,19 @@ export function PasswordResetForm() {
               className="w-full"
               disabled={isLoading}
             >
-              {isLoading ? 'Sending reset link...' : 'Send Reset Link'}
+              {isLoading ? 'Siunčiama nuoroda...' : 'Siųsti nuorodą'}
             </Button>
           </form>
         </Form>
       </CardContent>
       <CardFooter className="flex justify-center">
         <div className="text-sm text-center">
-          Remember your password?{' '}
+          Prisiminate slaptažodį?{' '}
           <Link href="/login" className="text-primary hover:underline">
-            Sign in
+            Prisijungti
           </Link>
         </div>
       </CardFooter>
     </Card>
   )
-} 
+}

--- a/components/auth/profile-form.tsx
+++ b/components/auth/profile-form.tsx
@@ -59,13 +59,13 @@ export function ProfileForm() {
       router.push('/')
       router.refresh()
       toast({
-        title: 'Signed out',
-        description: 'You have been signed out successfully.',
+        title: 'Atsijungta',
+        description: 'Sėkmingai atsijungėte.',
       })
     } catch (error: any) {
       toast({
-        title: 'Error',
-        description: error.message || 'Something went wrong',
+        title: 'Klaida',
+        description: error.message || 'Įvyko klaida',
         variant: 'destructive',
       })
     } finally {
@@ -103,15 +103,15 @@ export function ProfileForm() {
       }
       
       toast({
-        title: 'Subscription upgraded',
-        description: 'Your account has been upgraded to Premium.',
+        title: 'Prenumerata atnaujinta',
+        description: 'Jūsų paskyra atnaujinta į Premium.',
       })
       
       router.refresh()
     } catch (error: any) {
       toast({
-        title: 'Error',
-        description: error.message || 'Failed to upgrade subscription',
+        title: 'Klaida',
+        description: error.message || 'Nepavyko atnaujinti prenumeratos',
         variant: 'destructive',
       })
     } finally {
@@ -125,23 +125,23 @@ export function ProfileForm() {
   return (
     <Card className="w-full max-w-3xl mx-auto">
       <CardHeader>
-        <CardTitle>My Profile</CardTitle>
+        <CardTitle>Mano profilis</CardTitle>
         <CardDescription>
-          Manage your account settings and subscription
+          Tvarkykite paskyros nustatymus ir prenumeratą
         </CardDescription>
       </CardHeader>
       <CardContent>
         <Tabs defaultValue="account">
           <TabsList className="mb-4">
-            <TabsTrigger value="account">Account</TabsTrigger>
-            <TabsTrigger value="subscription">Subscription</TabsTrigger>
+            <TabsTrigger value="account">Paskyra</TabsTrigger>
+            <TabsTrigger value="subscription">Prenumerata</TabsTrigger>
           </TabsList>
           
           <TabsContent value="account" className="space-y-6">
             <div>
-              <h3 className="text-lg font-medium">Account Information</h3>
+              <h3 className="text-lg font-medium">Paskyros informacija</h3>
               <p className="text-sm text-muted-foreground">
-                Update your account details.
+                Atnaujinkite paskyros informaciją.
               </p>
             </div>
             
@@ -152,7 +152,7 @@ export function ProfileForm() {
                   name="email"
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Email</FormLabel>
+                      <FormLabel>El. paštas</FormLabel>
                       <FormControl>
                         <Input {...field} disabled />
                       </FormControl>
@@ -167,7 +167,7 @@ export function ProfileForm() {
                     variant="outline"
                     onClick={() => router.push('/reset-password')}
                   >
-                    Change Password
+                    Keisti slaptažodį
                   </Button>
                   
                   <Button
@@ -176,7 +176,7 @@ export function ProfileForm() {
                     onClick={handleSignOut}
                     disabled={isLoading}
                   >
-                    {isLoading ? 'Signing out...' : 'Sign Out'}
+                    {isLoading ? 'Atsijungiama...' : 'Atsijungti'}
                   </Button>
                 </div>
               </form>
@@ -185,51 +185,51 @@ export function ProfileForm() {
           
           <TabsContent value="subscription" className="space-y-6">
             <div>
-              <h3 className="text-lg font-medium">Subscription Information</h3>
+              <h3 className="text-lg font-medium">Prenumeratos informacija</h3>
               <p className="text-sm text-muted-foreground">
-                Manage your subscription plan.
+                Tvarkykite prenumeratos planą.
               </p>
             </div>
             
             <div className="space-y-4">
               <div className="bg-muted p-4 rounded-md">
-                <h4 className="font-medium">Current Plan</h4>
+                <h4 className="font-medium">Dabartinis planas</h4>
                 <p className="text-sm">
-                  {isAdminUser && 'Administrator'}
+                  {isAdminUser && 'Administratorius'}
                   {isPremiumUser && !isAdminUser && 'Premium'}
-                  {!isPremiumUser && !isAdminUser && 'Free'}
+                  {!isPremiumUser && !isAdminUser && 'Nemokama'}
                 </p>
               </div>
               
               {!isPremiumUser && !isAdminUser && (
                 <div className="p-4 border rounded-md">
-                  <h4 className="font-medium">Upgrade to Premium</h4>
+                  <h4 className="font-medium">Aukštinkite į Premium</h4>
                   <p className="text-sm mt-1 mb-4">
-                    Get unlimited access to all premium content and features.
+                    Gaukite neribotą prieigą prie viso premium turinio ir funkcijų.
                   </p>
-                  <Button 
+                  <Button
                     onClick={upgradeToPremium}
                     disabled={isLoading}
                   >
-                    {isLoading ? 'Processing...' : 'Upgrade Now'}
+                    {isLoading ? 'Apdorojama...' : 'Aukštinti dabar'}
                   </Button>
                 </div>
               )}
               
               {isPremiumUser && !isAdminUser && (
                 <div className="p-4 border rounded-md">
-                  <h4 className="font-medium">Premium Plan</h4>
+                  <h4 className="font-medium">Premium planas</h4>
                   <p className="text-sm mt-1">
-                    You have access to all premium content and features.
+                    Turite prieigą prie viso premium turinio ir funkcijų.
                   </p>
                 </div>
               )}
               
               {isAdminUser && (
                 <div className="p-4 border rounded-md">
-                  <h4 className="font-medium">Administrator Plan</h4>
+                  <h4 className="font-medium">Administratoriaus planas</h4>
                   <p className="text-sm mt-1">
-                    You have full administrative access to the platform.
+                    Turite visą administratoriaus prieigą prie platformos.
                   </p>
                 </div>
               )}

--- a/components/auth/protected-route.tsx
+++ b/components/auth/protected-route.tsx
@@ -44,8 +44,8 @@ export function ProtectedRoute({
       if (requiredRole !== UserRoles.FREE && !hasMinimumRole(requiredRole)) {
         console.log(`Role check failed: user does not have minimum required role: ${requiredRole}`);
         toast({
-          title: 'Access denied',
-          description: `You need ${requiredRole} access to view this page.`,
+          title: 'Prieiga uždrausta',
+          description: `Jums reikia ${requiredRole} prieigos, kad matytumėte šį puslapį.`,
           variant: 'destructive',
         });
         router.push('/');
@@ -59,8 +59,8 @@ export function ProtectedRoute({
         const returnUrl = forcedReturnUrl || pathname;
         const encodedReturnUrl = encodeURIComponent(returnUrl);
         toast({
-          title: 'Authentication required',
-          description: 'Please sign in to access this page',
+          title: 'Reikalingas autentifikavimas',
+          description: 'Prisijunkite, kad pasiektumėte šį puslapį',
           variant: 'destructive',
         });
         router.push(`/login?returnUrl=${encodedReturnUrl}`);
@@ -72,7 +72,7 @@ export function ProtectedRoute({
     return (
       <div className="flex items-center justify-center h-full w-full py-8">
         <Loader2 className="h-8 w-8 animate-spin" />
-        <span className="ml-2">Checking authentication...</span>
+        <span className="ml-2">Tikrinama autentifikacija...</span>
       </div>
     );
   }

--- a/components/auth/sign-in-form.tsx
+++ b/components/auth/sign-in-form.tsx
@@ -23,8 +23,8 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import Link from 'next/link'
 
 const formSchema = z.object({
-  email: z.string().email({ message: 'Please enter a valid email address.' }),
-  password: z.string().min(6, { message: 'Password must be at least 6 characters.' }),
+  email: z.string().email({ message: 'Įveskite teisingą el. pašto adresą.' }),
+  password: z.string().min(6, { message: 'Slaptažodis turi būti bent 6 simbolių.' }),
 })
 
 type FormValues = z.infer<typeof formSchema>
@@ -68,8 +68,8 @@ export function SignInForm() {
       
       // If signIn didn't throw an error, show success toast and redirect
       toast({
-        title: 'Success',
-        description: 'You have been signed in',
+        title: 'Sėkmingai',
+        description: 'Jūs prisijungėte',
       })
       
       // Redirect to callback URL if provided, otherwise go to homepage
@@ -80,8 +80,8 @@ export function SignInForm() {
       // or other unexpected errors during the process.
       // However, the current signIn implementation catches its own Supabase errors.
       toast({
-        title: 'Error',
-        description: error.message || 'An unexpected error occurred',
+        title: 'Klaida',
+        description: error.message || 'Įvyko netikėta klaida',
         variant: 'destructive',
       })
     } finally {
@@ -92,9 +92,9 @@ export function SignInForm() {
   return (
     <Card className="w-full max-w-md mx-auto">
       <CardHeader>
-        <CardTitle>Sign In</CardTitle>
+        <CardTitle>Prisijungti</CardTitle>
         <CardDescription>
-          Enter your email and password to access your account
+          Įveskite el. paštą ir slaptažodį, kad pasiektumėte paskyrą
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -105,7 +105,7 @@ export function SignInForm() {
               name="email"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Email</FormLabel>
+                  <FormLabel>El. paštas</FormLabel>
                   <FormControl>
                     <Input 
                       placeholder="email@example.com" 
@@ -123,7 +123,7 @@ export function SignInForm() {
               name="password"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Password</FormLabel>
+                  <FormLabel>Slaptažodis</FormLabel>
                   <FormControl>
                     <Input 
                       placeholder="••••••••" 
@@ -141,7 +141,7 @@ export function SignInForm() {
               className="w-full"
               disabled={isLoading}
             >
-              {isLoading ? 'Signing in...' : 'Sign In'}
+              {isLoading ? 'Prisijungiama...' : 'Prisijungti'}
             </Button>
           </form>
         </Form>
@@ -149,13 +149,13 @@ export function SignInForm() {
       <CardFooter className="flex flex-col space-y-2">
         <div className="text-sm text-center">
           <Link href="/reset-password" className="text-primary hover:underline">
-            Forgot password?
+            Pamiršote slaptažodį?
           </Link>
         </div>
         <div className="text-sm text-center">
-          Don&apos;t have an account?{' '}
+          Neturite paskyros?{' '}
           <Link href="/signup" className="text-primary hover:underline">
-            Sign up
+            Registruotis
           </Link>
         </div>
       </CardFooter>

--- a/components/auth/update-password-form.tsx
+++ b/components/auth/update-password-form.tsx
@@ -1,11 +1,9 @@
 'use client'
 
 import { useState } from 'react'
-import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import * as z from 'zod'
-import { toast } from '@/hooks/use-toast'
 import { useAuth } from '@/hooks/useAuth'
 
 // UI components
@@ -23,11 +21,11 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 
 const formSchema = z.object({
   password: z.string()
-    .min(6, { message: 'Password must be at least 6 characters.' })
-    .max(72, { message: 'Password must be less than 72 characters.' }),
-  confirmPassword: z.string()
+    .min(6, { message: 'Slaptažodis turi būti bent 6 simbolių.' })
+    .max(72, { message: 'Slaptažodis turi būti trumpesnis nei 72 simboliai.' }),
+  confirmPassword: z.string(),
 }).refine((data) => data.password === data.confirmPassword, {
-  message: 'Passwords do not match.',
+  message: 'Slaptažodžiai nesutampa.',
   path: ['confirmPassword'],
 })
 
@@ -35,9 +33,7 @@ type FormValues = z.infer<typeof formSchema>
 
 export function UpdatePasswordForm() {
   const { updatePassword } = useAuth()
-  const router = useRouter()
   const [isLoading, setIsLoading] = useState(false)
-  const [isSubmitted, setIsSubmitted] = useState(false)
 
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema),
@@ -51,13 +47,12 @@ export function UpdatePasswordForm() {
     if (values.password !== values.confirmPassword) {
       return
     }
-    
+
     setIsLoading(true)
     try {
       await updatePassword(values.password)
-      
+
       // Password update was successful, handled by the useAuth hook
-      setIsSubmitted(true)
     } catch (error) {
       // Error is handled by the useAuth hook, which shows a toast
       console.error('Error during password update:', error)
@@ -69,9 +64,9 @@ export function UpdatePasswordForm() {
   return (
     <Card className="w-full max-w-md mx-auto">
       <CardHeader>
-        <CardTitle>Update Password</CardTitle>
+        <CardTitle>Atnaujinti slaptažodį</CardTitle>
         <CardDescription>
-          Please enter a new password for your account.
+          Įveskite naują slaptažodį savo paskyrai.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -82,11 +77,11 @@ export function UpdatePasswordForm() {
               name="password"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>New Password</FormLabel>
+                  <FormLabel>Naujas slaptažodis</FormLabel>
                   <FormControl>
-                    <Input 
-                      placeholder="••••••••" 
-                      type="password" 
+                    <Input
+                      placeholder="••••••••"
+                      type="password"
                       {...field}
                       disabled={isLoading}
                     />
@@ -100,11 +95,11 @@ export function UpdatePasswordForm() {
               name="confirmPassword"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Confirm New Password</FormLabel>
+                  <FormLabel>Pakartokite naują slaptažodį</FormLabel>
                   <FormControl>
-                    <Input 
-                      placeholder="••••••••" 
-                      type="password" 
+                    <Input
+                      placeholder="••••••••"
+                      type="password"
                       {...field}
                       disabled={isLoading}
                     />
@@ -113,21 +108,22 @@ export function UpdatePasswordForm() {
                 </FormItem>
               )}
             />
-            <Button 
-              type="submit" 
+            <Button
+              type="submit"
               className="w-full"
               disabled={isLoading}
             >
-              {isLoading ? 'Updating password...' : 'Update Password'}
+              {isLoading ? 'Atnaujinama...' : 'Atnaujinti slaptažodį'}
             </Button>
           </form>
         </Form>
       </CardContent>
       <CardFooter className="flex justify-center">
         <p className="text-sm text-muted-foreground">
-          Make sure to choose a strong, unique password you don&apos;t use elsewhere.
+          Pasirinkite stiprų, unikalų slaptažodį, kurio nenaudojate kitur.
         </p>
       </CardFooter>
     </Card>
   )
-} 
+}
+

--- a/components/ui/navigation.tsx
+++ b/components/ui/navigation.tsx
@@ -124,7 +124,7 @@ export function Navigation() {
                             className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
                             onClick={() => setIsMenuOpen(false)}
                           >
-                            Debug Storage
+                            Derinti saugyklą
                           </Link>
                         </>
                       )}
@@ -158,7 +158,7 @@ export function Navigation() {
               onClick={() => setIsMenuOpen(!isMenuOpen)}
               className="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-secondary-navy"
             >
-              <span className="sr-only">Open main menu</span>
+              <span className="sr-only">Atverti pagrindinį meniu</span>
               {isMenuOpen ? (
                 <svg className="block h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
@@ -223,7 +223,7 @@ export function Navigation() {
                   }`}
                   onClick={() => setIsMenuOpen(false)}
                 >
-                  Debug Storage
+                  Derinti saugyklą
                 </Link>
               </>
             )}
@@ -280,7 +280,7 @@ export function Navigation() {
                       className="block w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:bg-gray-100"
                       onClick={() => setIsMenuOpen(false)}
                     >
-                      Debug Storage
+                      Derinti saugyklą
                     </Link>
                   </>
                 )}

--- a/hooks/useAuth.tsx
+++ b/hooks/useAuth.tsx
@@ -151,8 +151,8 @@ export function AuthProvider({
     if (!supabase) {
       toast({
         variant: 'destructive',
-        title: 'Error',
-        description: 'Authentication service unavailable.',
+        title: 'Klaida',
+        description: 'Autentifikavimo paslauga nepasiekiama.',
       })
       return
     }
@@ -173,16 +173,16 @@ export function AuthProvider({
 
       // Redirect the user to the confirmation page
       toast({
-        title: 'Success',
+        title: 'Sėkmingai',
         description:
-          'Registration successful! Please check your email for a confirmation link.',
+          'Registracija sėkminga! Patikrinkite el. paštą dėl patvirtinimo nuorodos.',
       })
       router.push('/auth/confirm')
     } catch (error: any) {
       toast({
         variant: 'destructive',
-        title: 'Error',
-        description: error.message || 'An error occurred during sign up.',
+        title: 'Klaida',
+        description: error.message || 'Registruojantis įvyko klaida.',
       })
       console.error('Error signing up:', error)
     } finally {
@@ -195,8 +195,8 @@ export function AuthProvider({
     if (!supabase) {
       toast({
         variant: 'destructive',
-        title: 'Error',
-        description: 'Authentication service unavailable.',
+        title: 'Klaida',
+        description: 'Autentifikavimo paslauga nepasiekiama.',
       })
       return
     }
@@ -219,8 +219,8 @@ export function AuthProvider({
     } catch (error: any) {
       toast({
         variant: 'destructive',
-        title: 'Error',
-        description: error.message || 'An error occurred during sign in.',
+        title: 'Klaida',
+        description: error.message || 'Prisijungiant įvyko klaida.',
       })
       console.error('Error signing in:', error)
     } finally {
@@ -233,8 +233,8 @@ export function AuthProvider({
     if (!supabase) {
       toast({
         variant: 'destructive',
-        title: 'Error',
-        description: 'Authentication service unavailable.',
+        title: 'Klaida',
+        description: 'Autentifikavimo paslauga nepasiekiama.',
       })
       return
     }
@@ -258,8 +258,8 @@ export function AuthProvider({
     } catch (error: any) {
       toast({
         variant: 'destructive',
-        title: 'Error',
-        description: error.message || 'An error occurred during sign out.',
+        title: 'Klaida',
+        description: error.message || 'Atsijungiant įvyko klaida.',
       })
       console.error('Error signing out:', error)
     } finally {
@@ -272,8 +272,8 @@ export function AuthProvider({
     if (!supabase) {
       toast({
         variant: 'destructive',
-        title: 'Error',
-        description: 'Authentication service unavailable.',
+        title: 'Klaida',
+        description: 'Autentifikavimo paslauga nepasiekiama.',
       })
       return
     }
@@ -291,16 +291,16 @@ export function AuthProvider({
       }
 
       toast({
-        title: 'Success',
+        title: 'Sėkmingai',
         description:
-          'Password reset email sent! Please check your email for further instructions.',
+          'Slaptažodžio atstatymo laiškas išsiųstas! Patikrinkite el. paštą dėl tolimesnių nurodymų.',
       })
       router.push('/auth/confirm')
     } catch (error: any) {
       toast({
         variant: 'destructive',
-        title: 'Error',
-        description: error.message || 'An error occurred during password reset.',
+        title: 'Klaida',
+        description: error.message || 'Slaptažodžio atstatymo metu įvyko klaida.',
       })
       console.error('Error resetting password:', error)
     } finally {
@@ -313,8 +313,8 @@ export function AuthProvider({
     if (!supabase) {
       toast({
         variant: 'destructive',
-        title: 'Error',
-        description: 'Authentication service unavailable.',
+        title: 'Klaida',
+        description: 'Autentifikavimo paslauga nepasiekiama.',
       })
       return
     }
@@ -330,15 +330,15 @@ export function AuthProvider({
       }
 
       toast({
-        title: 'Success',
-        description: 'Password updated successfully!',
+        title: 'Sėkmingai',
+        description: 'Slaptažodis sėkmingai atnaujintas!',
       })
       router.push('/')
     } catch (error: any) {
       toast({
         variant: 'destructive',
-        title: 'Error',
-        description: error.message || 'An error occurred during password update.',
+        title: 'Klaida',
+        description: error.message || 'Slaptažodžio atnaujinimo metu įvyko klaida.',
       })
       console.error('Error updating password:', error)
     } finally {


### PR DESCRIPTION
## Summary
- translate login, password reset, navigation and error messages to Lithuanian
- localize authentication flows and profile management

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d72c6c330832a894ab12bb9e5b31e