### PR TITLE
feat: show attachments below metadata

### DIFF
--- a/components/content/content-detail.tsx
+++ b/components/content/content-detail.tsx
@@ -276,11 +276,6 @@ export function ContentDetail({ content }: ContentDetailProps) {
             </div>
           )}
 
-          {/* Attachments Section */}
-          {content.metadata?.attachments && content.metadata.attachments.length > 0 && (
-            <SimpleContentDetailAttachments attachments={content.metadata.attachments} />
-          )}
-
           {/* Feedback Section */}
           <ContentDetailFeedback content={content} />
         </div>
@@ -308,8 +303,13 @@ export function ContentDetail({ content }: ContentDetailProps) {
           <div className="bg-gray-50 rounded-lg p-4 space-y-4">
             <ContentDetailMetadata content={content} />
           </div>
+
+          {/* Attachments */}
+          {content.metadata?.attachments && content.metadata.attachments.length > 0 && (
+            <SimpleContentDetailAttachments attachments={content.metadata.attachments} />
+          )}
         </aside>
       </div>
     </div>
   )
-} 
+}

--- a/components/content/simple-content-detail-attachments.tsx
+++ b/components/content/simple-content-detail-attachments.tsx
@@ -19,8 +19,8 @@ export function SimpleContentDetailAttachments({ attachments }: SimpleContentDet
   }
 
   return (
-    <div className="mt-6 border rounded-lg p-4">
-      <h3 className="font-medium mb-2">Pridėti failai</h3>
+    <div className="border rounded-lg p-4">
+      <h3 className="font-medium mb-2">Priedai</h3>
       <ul className="space-y-2">
         {attachments.map((file) => (
           <li key={file.id} className="flex items-center">


### PR DESCRIPTION
## Summary
- show downloadable attachments in content sidebar under metadata
- label attachments section as 'Priedai'

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68a76d021bc8832a8ae5106795dcef66