### PR TITLE
feat: add client-side search for content titles

### DIFF
--- a/app/(main)/home-client-content.tsx
+++ b/app/(main)/home-client-content.tsx
@@ -173,14 +173,11 @@ export function HomeClientContent({
   return (
     <>
       {showEditButtons && (
-        <div className="mb-4 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
-          <div className="flex justify-between items-center">
-            <div>
-              <h3 className="font-medium text-yellow-800">Administratoriaus režimas</h3>
-              <p className="text-sm text-yellow-600">Galite redaguoti turinį tiesiogiai šiame puslapyje.</p>
-            </div>
+        <div className="mb-4 rounded-md border border-yellow-200 bg-yellow-50/60">
+          <div className="flex items-center justify-between gap-3 px-3 py-2">
+            <p className="text-xs text-yellow-700">Administratoriaus režimas · Galite redaguoti turinį šiuo puslapiu</p>
             <Link href="/manage/content/new">
-              <Button>Kurti naują turinį</Button>
+              <Button variant="outline" size="sm">Kurti naują turinį</Button>
             </Link>
           </div>
         </div>
@@ -188,6 +185,7 @@ export function HomeClientContent({
       
       
       
+      <div className="w-full overflow-x-hidden">
       <ContentLayout
         content={displayContent}
         ageGroups={ageGroups}
@@ -202,6 +200,7 @@ export function HomeClientContent({
         onRefresh={refresh}
         showEditButtons={showEditButtons}
       />
+      </div>
     </>
   )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -92,7 +92,7 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground overflow-x-hidden;
   }
 }
 

--- a/components/content/content-grid.tsx
+++ b/components/content/content-grid.tsx
@@ -74,7 +74,7 @@ export function ContentGrid({
 
   return (
     <ScrollArea className="h-[calc(100vh-12rem)] rounded-md">
-      <div className="p-4">
+      <div className="p-4 w-full overflow-x-hidden">
         {isLoading ? (
           <ContentSkeleton count={6} />
         ) : filteredForDisplay.length > 0 ? (

--- a/components/content/content-layout.tsx
+++ b/components/content/content-layout.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Tabs, TabsContent } from "@/components/ui/tabs"
+import { Input } from "@/components/ui/input"
+import { Search } from "lucide-react"
 import type { ContentItem, AgeGroup, Category } from "@/lib/types/database"
 import { ContentFilterSidebar } from './content-filter-sidebar'
 import { ContentTypeTabs } from './content-type-tabs'
@@ -47,6 +49,15 @@ export function ContentLayout({
 }: ContentLayoutProps) {
   const [filterOpen, setFilterOpen] = useState(false)
   const [activeTab, setActiveTab] = useState('all')
+  const [searchTerm, setSearchTerm] = useState('')
+
+  const filteredContent = useMemo(
+    () =>
+      content.filter(item =>
+        item.title.toLowerCase().includes(searchTerm.toLowerCase())
+      ),
+    [content, searchTerm]
+  )
 
   // Create the filter sidebar component that will be used in both desktop and mobile views
   const filterSidebar = (
@@ -80,6 +91,17 @@ export function ContentLayout({
           onValueChange={(value) => setActiveTab(value)}
         >
           <div className="px-4 py-6">
+            <div className="mb-4">
+              <div className="relative max-w-md">
+                <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+                <Input
+                  placeholder="Ieškoti turinio..."
+                  className="pl-8"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                />
+              </div>
+            </div>
             <ContentTypeTabs
               onRefresh={onRefresh}
               filterSidebar={filterSidebar}
@@ -90,7 +112,7 @@ export function ContentLayout({
             {/* All Content Tab */}
             <TabsContent value="all" className="m-0">
               <ContentGrid
-                content={content}
+                content={filteredContent}
                 isLoading={isLoading}
                 showPremiumOnly={showPremiumOnly}
                 contentType="all"
@@ -101,7 +123,7 @@ export function ContentLayout({
             {/* Video Content Tab */}
             <TabsContent value="video" className="m-0">
               <ContentGrid
-                content={content}
+                content={filteredContent}
                 isLoading={isLoading}
                 showPremiumOnly={showPremiumOnly}
                 contentType="video"
@@ -112,7 +134,7 @@ export function ContentLayout({
             {/* Audio Content Tab */}
             <TabsContent value="audio" className="m-0">
               <ContentGrid
-                content={content}
+                content={filteredContent}
                 isLoading={isLoading}
                 showPremiumOnly={showPremiumOnly}
                 contentType="audio"
@@ -123,7 +145,7 @@ export function ContentLayout({
             {/* Lesson Plan Content Tab */}
             <TabsContent value="lesson_plan" className="m-0">
               <ContentGrid
-                content={content}
+                content={filteredContent}
                 isLoading={isLoading}
                 showPremiumOnly={showPremiumOnly}
                 contentType="lesson_plan"
@@ -134,7 +156,7 @@ export function ContentLayout({
             {/* Game Content Tab */}
             <TabsContent value="game" className="m-0">
               <ContentGrid
-                content={content}
+                content={filteredContent}
                 isLoading={isLoading}
                 showPremiumOnly={showPremiumOnly}
                 contentType="game"

--- a/components/content/content-layout.tsx
+++ b/components/content/content-layout.tsx
@@ -75,7 +75,7 @@ export function ContentLayout({
   )
 
   return (
-    <div className="flex h-full">
+    <div className="flex h-full w-full overflow-x-hidden">
       {/* Desktop Sidebar */}
       <div className="hidden lg:block w-[300px] border-r border-gray-200">
         <ScrollArea className="h-[calc(100vh-8rem)] px-4 py-6">
@@ -84,29 +84,20 @@ export function ContentLayout({
       </div>
 
       {/* Main Content */}
-      <div className="flex-1">
+      <div className="flex-1 min-w-0">
         <Tabs 
           defaultValue="all" 
           className="h-full"
           onValueChange={(value) => setActiveTab(value)}
         >
           <div className="px-4 py-6">
-            <div className="mb-4">
-              <div className="relative max-w-md">
-                <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
-                <Input
-                  placeholder="Ieškoti turinio..."
-                  className="pl-8"
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                />
-              </div>
-            </div>
             <ContentTypeTabs
               onRefresh={onRefresh}
               filterSidebar={filterSidebar}
               isFilterOpen={filterOpen}
               onFilterOpenChange={setFilterOpen}
+              searchTerm={searchTerm}
+              onSearchChange={setSearchTerm}
             />
 
             {/* All Content Tab */}

--- a/components/content/content-type-tabs.tsx
+++ b/components/content/content-type-tabs.tsx
@@ -3,6 +3,8 @@
 import { TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { FunnelIcon } from "@heroicons/react/24/solid"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Search } from "lucide-react"
 import {
   Sheet,
   SheetContent,
@@ -18,6 +20,8 @@ interface ContentTypeTabsProps {
   filterSidebar: ReactNode
   isFilterOpen: boolean
   onFilterOpenChange: (open: boolean) => void
+  searchTerm: string
+  onSearchChange: (value: string) => void
 }
 
 /**
@@ -32,11 +36,13 @@ export function ContentTypeTabs({
   onRefresh,
   filterSidebar,
   isFilterOpen,
-  onFilterOpenChange
+  onFilterOpenChange,
+  searchTerm,
+  onSearchChange
 }: ContentTypeTabsProps) {
   return (
-    <div className="flex flex-col sm:flex-row gap-4 sm:items-center sm:justify-between mb-6">
-      <div className="flex items-center gap-4">
+    <div className="flex flex-col sm:flex-row gap-4 sm:items-center sm:justify-between mb-6 w-full">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 sm:gap-4 w-full">
         {/* Mobile Filter Button */}
         <Sheet open={isFilterOpen} onOpenChange={onFilterOpenChange}>
           <SheetTrigger asChild>
@@ -53,38 +59,50 @@ export function ContentTypeTabs({
             </ScrollArea>
           </SheetContent>
         </Sheet>
-        <TabsList className="bg-secondary-navy/10">
+        <TabsList className="bg-secondary-navy/10 w-full overflow-x-auto whitespace-nowrap justify-start pl-3 pr-3 gap-2 snap-x">
           <TabsTrigger 
             value="all" 
-            className="data-[state=active]:bg-secondary-navy data-[state=active]:text-white"
+            className="data-[state=active]:bg-secondary-navy data-[state=active]:text-white shrink-0 snap-start"
           >
             Visi
           </TabsTrigger>
           <TabsTrigger 
             value="video"
-            className="data-[state=active]:bg-secondary-navy data-[state=active]:text-white"
+            className="data-[state=active]:bg-secondary-navy data-[state=active]:text-white shrink-0 snap-start"
           >
             Video
           </TabsTrigger>
           <TabsTrigger 
             value="audio"
-            className="data-[state=active]:bg-secondary-navy data-[state=active]:text-white"
+            className="data-[state=active]:bg-secondary-navy data-[state=active]:text-white shrink-0 snap-start"
           >
             Dainos
           </TabsTrigger>
           <TabsTrigger 
             value="lesson_plan"
-            className="data-[state=active]:bg-secondary-navy data-[state=active]:text-white"
+            className="data-[state=active]:bg-secondary-navy data-[state=active]:text-white shrink-0 snap-start"
           >
             Pamokos
           </TabsTrigger>
           <TabsTrigger 
             value="game"
-            className="data-[state=active]:bg-secondary-navy data-[state=active]:text-white"
+            className="data-[state=active]:bg-secondary-navy data-[state=active]:text-white shrink-0 snap-start"
           >
             Žaidimai
           </TabsTrigger>
         </TabsList>
+      </div>
+      {/* Search - mobile full width below tabs; desktop right-aligned */}
+      <div className="w-full sm:max-w-xs sm:ml-auto">
+        <div className="relative">
+          <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Ieškoti turinio..."
+            className="pl-8"
+            value={searchTerm}
+            onChange={(e) => onSearchChange(e.target.value)}
+          />
+        </div>
       </div>
       <Button
         onClick={onRefresh}


### PR DESCRIPTION
## Summary
- add search bar to content layout for filtering by title
- filter displayed content on the client for fast results

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ac92ff0bd8832aa738dffd1311290c