### PR TITLE
fix: show categories by content type

### DIFF
--- a/components/content/content-layout.tsx
+++ b/components/content/content-layout.tsx
@@ -75,7 +75,10 @@ export function ContentLayout({
     for (const item of allContent) {
       const ids = item.categories.map((c) => c.id)
       ids.forEach((id) => map.all.add(id))
-      const key = (item as any)?.metadata?.ui_type || item.type
+      const key =
+        (item as any)?.ui_type?.slug ||
+        (item as any)?.metadata?.ui_type ||
+        item.type
       if (!map[key]) map[key] = new Set()
       ids.forEach((id) => map[key].add(id))
     }


### PR DESCRIPTION
## Summary
- use ui type slug when grouping categories per content type so filter sidebar shows relevant categories

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3492f38d4832aa864f3672c5acd08