### PR TITLE
Improve mobile layout for Medziaga pages

### DIFF
--- a/components/content/content-detail-metadata.tsx
+++ b/components/content/content-detail-metadata.tsx
@@ -19,38 +19,38 @@ interface ContentDetailMetadataProps {
  */
 export function ContentDetailMetadata({ content }: ContentDetailMetadataProps) {
   return (
-    <div className="space-y-6">
+    <div className="space-y-4 md:space-y-6 text-sm md:text-base">
       {/* Age Groups */}
-      <div className="mb-6">
-        <h2 className="text-lg font-medium text-gray-900 mb-2">Amžiaus grupės:</h2>
+      <div className="mb-4 md:mb-6">
+        <h2 className="text-base md:text-lg font-medium text-gray-900 mb-2">Amžiaus grupės:</h2>
         <div className="flex flex-wrap gap-2">
           {content.age_groups.map((group) => (
-            <AgeGroupBadge 
-              key={group.id} 
-              ageGroup={group} 
-              variant="pill" 
+            <AgeGroupBadge
+              key={group.id}
+              ageGroup={group}
+              variant="pill"
             />
           ))}
         </div>
       </div>
 
       {/* Categories */}
-      <div className="mb-6">
-        <h2 className="text-lg font-medium text-gray-900 mb-2">Temos:</h2>
+      <div className="mb-4 md:mb-6">
+        <h2 className="text-base md:text-lg font-medium text-gray-900 mb-2">Temos:</h2>
         <div className="flex flex-wrap gap-2">
           {content.categories.map((category) => (
-            <CategoryBadge 
-              key={category.id} 
-              category={category} 
-              variant="pill" 
+            <CategoryBadge
+              key={category.id}
+              category={category}
+              variant="pill"
             />
           ))}
         </div>
       </div>
 
       {/* Content Type */}
-      <div className="mb-8">
-        <h2 className="text-lg font-medium text-gray-900 mb-2">Turinio tipas:</h2>
+      <div className="mb-6 md:mb-8">
+        <h2 className="text-base md:text-lg font-medium text-gray-900 mb-2">Turinio tipas:</h2>
         <ContentTypeBadge 
           type={(content as any)?.ui_type?.slug || (content as any)?.metadata?.ui_type || content.type} 
           variant="pill" 
@@ -59,11 +59,11 @@ export function ContentDetailMetadata({ content }: ContentDetailMetadataProps) {
 
       {/* Description */}
       {content.description && (
-        <div className="mb-6">
-          <h2 className="text-lg font-medium text-gray-900 mb-2">Aprašymas:</h2>
+        <div className="mb-4 md:mb-6">
+          <h2 className="text-base md:text-lg font-medium text-gray-900 mb-2">Aprašymas:</h2>
           <p className="text-gray-700 whitespace-pre-line">{content.description}</p>
         </div>
       )}
     </div>
   )
-} 
+}

--- a/components/content/content-detail.tsx
+++ b/components/content/content-detail.tsx
@@ -295,7 +295,12 @@ export function ContentDetail({ content, hideThumbnail = false, nextSlug, prevSl
               />
             </div>
           )}
-
+          {/* Attachments (mobile) */}
+          {content.metadata?.attachments && content.metadata.attachments.length > 0 && (
+            <div className="lg:hidden">
+              <SimpleContentDetailAttachments attachments={content.metadata.attachments} />
+            </div>
+          )}
 
           {/* Main Content Body */}
           {/* Minimal debug only during development */}
@@ -316,7 +321,7 @@ export function ContentDetail({ content, hideThumbnail = false, nextSlug, prevSl
         <aside className="lg:col-span-3 space-y-6">
           {/* Thumbnail */}
           {!hideThumbnail && content.thumbnail_url && (
-            <div className="rounded-lg overflow-hidden relative aspect-video">
+            <div className="hidden lg:block rounded-lg overflow-hidden relative aspect-video">
               <Image
                 src={content.thumbnail_url}
                 alt={content.title}
@@ -338,7 +343,9 @@ export function ContentDetail({ content, hideThumbnail = false, nextSlug, prevSl
 
           {/* Attachments */}
           {content.metadata?.attachments && content.metadata.attachments.length > 0 && (
-            <SimpleContentDetailAttachments attachments={content.metadata.attachments} />
+            <div className="hidden lg:block">
+              <SimpleContentDetailAttachments attachments={content.metadata.attachments} />
+            </div>
           )}
         </aside>
       </div>


### PR DESCRIPTION
## Summary
- show attachments at top on mobile for quick access
- hide duplicate sidebar thumbnail on small screens
- reduce metadata text sizes for better mobile readability

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68b30601e4cc832aa2816df057a9ce68