### PR TITLE
Rename categories to topics in UI

### DIFF
--- a/app/manage/categories/category-manager.tsx
+++ b/app/manage/categories/category-manager.tsx
@@ -96,7 +96,7 @@ export default function CategoryManager({ initialCategories }: CategoryManagerPr
 
   const handleCreateCategory = useCallback(async () => {
     if (!newCategoryName.trim()) {
-      setError('Kategorijos pavadinimas negali būti tuščias')
+      setError('Temos pavadinimas negali būti tuščias')
       return
     }
     setError(null)
@@ -119,16 +119,16 @@ export default function CategoryManager({ initialCategories }: CategoryManagerPr
 
       if (!response.ok) {
         setError(data.error || `HTTP error! status: ${response.status}`);
-        toast.error(data.error || 'Nepavyko sukurti kategorijos');
+        toast.error(data.error || 'Nepavyko sukurti temos');
       } else {
         setCategories(prev => [...prev, { ...data, usageCount: 0, isLoadingUsage: false }]);
         setNewCategoryName('');
         setNewCategoryDescription('');
-        toast.success('Kategorija sėkmingai sukurta');
+        toast.success('Tema sėkmingai sukurta');
       }
     } catch (err) {
       console.error('Error creating category:', err);
-      const message = err instanceof Error ? err.message : 'Įvyko tinklo klaida kuriant kategoriją';
+      const message = err instanceof Error ? err.message : 'Įvyko tinklo klaida kuriant temą';
       setError(message);
       toast.error(message);
     } finally {
@@ -164,11 +164,11 @@ export default function CategoryManager({ initialCategories }: CategoryManagerPr
         setCategories(prev => prev.filter(c => c.id !== selectedCategory.id));
         setIsDeleteDialogOpen(false);
         setSelectedCategory(null);
-        toast.success(data.message || 'Kategorija sėkmingai ištrinta');
+        toast.success(data.message || 'Tema sėkmingai ištrinta');
       }
     } catch (err) {
       console.error('Error deleting category:', err);
-      const message = err instanceof Error ? err.message : 'Įvyko tinklo klaida trinant kategoriją';
+      const message = err instanceof Error ? err.message : 'Įvyko tinklo klaida trinant temą';
       toast.error(message);
     } finally {
       setIsDeleting(false);
@@ -185,7 +185,7 @@ export default function CategoryManager({ initialCategories }: CategoryManagerPr
 
       <Card>
         <CardHeader>
-          <CardTitle>Sukurti naują kategoriją</CardTitle>
+          <CardTitle>Sukurti naują temą</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
@@ -194,7 +194,7 @@ export default function CategoryManager({ initialCategories }: CategoryManagerPr
                 Pavadinimas <span className="text-red-500">*</span>
               </label>
               <Input
-                placeholder="Kategorijos pavadinimas"
+                placeholder="Temos pavadinimas"
                 value={newCategoryName}
                 onChange={(e) => setNewCategoryName(e.target.value)}
                 className="w-full"
@@ -205,7 +205,7 @@ export default function CategoryManager({ initialCategories }: CategoryManagerPr
                 Aprašymas (nebūtinas)
               </label>
               <Input
-                placeholder="Kategorijos aprašymas"
+                placeholder="Temos aprašymas"
                 value={newCategoryDescription}
                 onChange={(e) => setNewCategoryDescription(e.target.value)}
                 className="w-full"
@@ -224,7 +224,7 @@ export default function CategoryManager({ initialCategories }: CategoryManagerPr
               ) : (
                 <>
                   <Plus className="mr-2 h-4 w-4" />
-                  Sukurti kategoriją
+                  Sukurti temą
                 </>
               )}
             </Button>
@@ -235,11 +235,11 @@ export default function CategoryManager({ initialCategories }: CategoryManagerPr
 
       <Card>
         <CardHeader>
-          <CardTitle>Esamos kategorijos</CardTitle>
+          <CardTitle>Esamos temos</CardTitle>
         </CardHeader>
         <CardContent>
           {categories.length === 0 ? (
-            <p className="text-muted-foreground">Nėra sukurtų kategorijų</p>
+            <p className="text-muted-foreground">Nėra sukurtų temų</p>
           ) : (
             <ul className="divide-y">
               {categories.map((category) => (
@@ -281,12 +281,12 @@ export default function CategoryManager({ initialCategories }: CategoryManagerPr
       <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Ištrinti kategoriją</DialogTitle>
+            <DialogTitle>Ištrinti temą</DialogTitle>
             <DialogDescription>
               {selectedCategory?.usageCount !== undefined && selectedCategory.usageCount > 0 ? (
-                `Ši kategorija naudojama ${selectedCategory.usageCount} turinio elementuose. Ištrynus kategoriją, ji bus pašalinta iš visų turinio elementų.`
+                `Ši tema naudojama ${selectedCategory.usageCount} turinio elementuose. Ištrynus temą, ji bus pašalinta iš visų turinio elementų.`
               ) : (
-                'Ar tikrai norite ištrinti šią kategoriją?'
+                'Ar tikrai norite ištrinti šią temą?'
               )}
             </DialogDescription>
           </DialogHeader>

--- a/app/manage/categories/layout.tsx
+++ b/app/manage/categories/layout.tsx
@@ -1,8 +1,8 @@
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Kategorijų valdymas | Solis Admin',
-  description: 'Kategorijų valdymo puslapis administratoriams',
+  title: 'Temų valdymas | Solis Admin',
+  description: 'Temų valdymo puslapis administratoriams',
 }
 
 export default function CategoriesLayout({

--- a/app/manage/categories/page.tsx
+++ b/app/manage/categories/page.tsx
@@ -4,8 +4,8 @@ import CategoryManager from './category-manager'
 import type { Category } from '@/lib/types/database'
 
 export const metadata: Metadata = {
-  title: 'Kategorijų valdymas | Solis',
-  description: 'Solis platformos kategorijų valdymo skydelis',
+  title: 'Temų valdymas | Solis',
+  description: 'Solis platformos temų valdymo skydelis',
 }
 
 export default async function CategoriesPage() {
@@ -21,7 +21,7 @@ export default async function CategoriesPage() {
 
   return (
     <div className="container py-8">
-      <h1 className="text-3xl font-bold mb-6">Kategorijų valdymas</h1>
+      <h1 className="text-3xl font-bold mb-6">Temų valdymas</h1>
       <CategoryManager initialCategories={categories} />
     </div>
   )

--- a/app/manage/content/new/NewContentEditor.tsx
+++ b/app/manage/content/new/NewContentEditor.tsx
@@ -51,7 +51,7 @@ const formSchema = z.object({
   title: z.string().min(1, { message: "Pavadinimas privalomas" }),
   thumbnail: z.any().optional(),
   ageGroups: z.array(z.string()).min(1, { message: "Pasirinkite bent vieną amžiaus grupę" }),
-  categories: z.array(z.string()).min(1, { message: "Pasirinkite bent vieną kategoriją" }),
+  categories: z.array(z.string()).min(1, { message: "Pasirinkite bent vieną temą" }),
   accessTierId: z.string().min(1, { message: "Pasirinkite prieigos lygį" }),
   published: z.boolean().default(false),
   attachments: z.array(z.any()).optional(),
@@ -667,7 +667,7 @@ export function NewContentEditor({
                     />
                   </div>
                   
-                  {/* Auditorija ir kategorijos */}
+                  {/* Auditorija ir temos */}
                   <div className="space-y-6">
                     <h3 className="text-base font-semibold">Kam skirtas šis turinys?</h3>
               
@@ -700,8 +700,8 @@ export function NewContentEditor({
                           <CheckboxCardGroup
                             form={form}
                             name="categories"
-                            label="Kategorijos"
-                            description="Pasirinkite kategorijas, kurioms priklauso šis turinys"
+                            label="Temos"
+                            description="Pasirinkite temas, kurioms priklauso šis turinys"
                             items={categories
                               .slice()
                               .sort((a: any, b: any) => String(a?.name || '').localeCompare(String(b?.name || ''), 'lt', { sensitivity: 'base' }))

--- a/app/manage/page.tsx
+++ b/app/manage/page.tsx
@@ -19,16 +19,16 @@ export default async function AdminDashboardPage() {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Tag className="h-5 w-5" />
-              Kategorijų valdymas
+              Temų valdymas
             </CardTitle>
             <CardDescription>
-              Kurkite, redaguokite ir trinkite turinio kategorijas
+              Kurkite, redaguokite ir trinkite turinio temas
             </CardDescription>
           </CardHeader>
           <CardContent>
             <Link href="/manage/categories">
               <Button className="w-full">
-                Valdyti kategorijas
+                Valdyti temas
               </Button>
             </Link>
           </CardContent>

--- a/app/premium/premium-plans.tsx
+++ b/app/premium/premium-plans.tsx
@@ -59,7 +59,7 @@ export function PremiumPlans() {
                   </li>
                   <li className="flex">
                     <CheckIcon className="h-5 w-5 text-green-500 mr-2 flex-shrink-0" />
-                    <span>Turinio filtravimas pagal kategorijas</span>
+                    <span>Turinio filtravimas pagal temas</span>
                   </li>
                   <li className="flex opacity-50">
                     <span className="h-5 w-5 border border-gray-300 rounded-full mr-2 flex-shrink-0"></span>

--- a/components/content/content-detail-metadata.tsx
+++ b/components/content/content-detail-metadata.tsx
@@ -36,7 +36,7 @@ export function ContentDetailMetadata({ content }: ContentDetailMetadataProps) {
 
       {/* Categories */}
       <div className="mb-6">
-        <h2 className="text-lg font-medium text-gray-900 mb-2">Kategorijos:</h2>
+        <h2 className="text-lg font-medium text-gray-900 mb-2">Temos:</h2>
         <div className="flex flex-wrap gap-2">
           {content.categories.map((category) => (
             <CategoryBadge 

--- a/components/content/content-filter-sidebar.tsx
+++ b/components/content/content-filter-sidebar.tsx
@@ -84,7 +84,7 @@ export function ContentFilterSidebar({
       </div>
       <Separator />
       <div>
-        <h3 className="mb-2 text-lg font-semibold">Kategorijos</h3>
+        <h3 className="mb-2 text-lg font-semibold">Temos</h3>
         <div className="space-y-1">
           {categories.map((category) => (
             <button

--- a/components/content/content-form-metadata.tsx
+++ b/components/content/content-form-metadata.tsx
@@ -93,9 +93,9 @@ export function ContentFormMetadata({
       </div>
       
       <div className="mb-4">
-        <h3 className="text-lg font-medium mb-1">Kategorijos</h3>
+        <h3 className="text-lg font-medium mb-1">Temos</h3>
         <p className="text-sm text-muted-foreground mb-4">
-          Pasirinkite, kokioms kategorijoms priklauso šis turinys
+          Pasirinkite, kokioms temoms priklauso šis turinys
           <span className="text-destructive ml-1 font-medium">*</span>
         </p>
         
@@ -103,14 +103,14 @@ export function ContentFormMetadata({
           <CheckboxCardGroup
             form={form}
             name="categories"
-            label="Kategorijos"
+            label="Temos"
             items={categoryItems}
             accentColor="secondary-mint"
             columns={3}
           />
           
           {selectedCategories.length === 0 && form.formState.isSubmitted && (
-            <p className="text-destructive text-sm mt-2">Pasirinkite bent vieną kategoriją</p>
+            <p className="text-destructive text-sm mt-2">Pasirinkite bent vieną temą</p>
           )}
         </div>
       </div>

--- a/components/content/content-form-step-metadata.tsx
+++ b/components/content/content-form-step-metadata.tsx
@@ -22,7 +22,7 @@ import type { AgeGroup, Category, AccessTier } from "@/lib/types/database"
 
 const formSchema = z.object({
   ageGroups: z.array(z.string()).min(1, { message: "Pasirinkite bent vieną amžiaus grupę" }),
-  categories: z.array(z.string()).min(1, { message: "Pasirinkite bent vieną kategoriją" }),
+  categories: z.array(z.string()).min(1, { message: "Pasirinkite bent vieną temą" }),
   accessTierId: z.string().min(1, { message: "Pasirinkite prieigos lygį" }),
   published: z.boolean().default(false),
 })
@@ -103,8 +103,8 @@ export function ContentFormStepMetadata({
               <CheckboxCardGroup
                 form={form}
                 name="categories"
-                label="Kategorijos"
-                description="Pasirinkite kategorijas, kurioms priklauso turinys"
+                label="Temos"
+                description="Pasirinkite temas, kurioms priklauso turinys"
                 items={categories.map(category => ({
                   id: category.id,
                   label: category.name,

--- a/components/content/content-form-step-preview.tsx
+++ b/components/content/content-form-step-preview.tsx
@@ -93,7 +93,7 @@ export function ContentFormStepPreview({
             </div>
           </div>
           <div>
-            <h4 className="text-sm font-medium mb-2">Kategorijos</h4>
+            <h4 className="text-sm font-medium mb-2">Temos</h4>
             <div className="flex flex-wrap gap-2">
               {selectedCategories.map(category => (
                 <Badge key={category.id} variant="outline">

--- a/components/content/content-form.tsx
+++ b/components/content/content-form.tsx
@@ -70,7 +70,7 @@ const formSchema = z.object({
       z.string().min(1, { message: "Įveskite turinio turinį" })
     ),
   ageGroups: z.array(z.string()).min(1, { message: "Pasirinkite bent vieną amžiaus grupę" }),
-  categories: z.array(z.string()).min(1, { message: "Pasirinkite bent vieną kategoriją" }),
+  categories: z.array(z.string()).min(1, { message: "Pasirinkite bent vieną temą" }),
   accessTierId: z.string().min(1, { message: "Pasirinkite prieigos lygį" }),
   published: z.boolean().default(false),
 })
@@ -509,8 +509,8 @@ export function ContentForm({
                   <CheckboxCardGroup
                     form={form}
                     name="categories"
-                    label="Kategorijos"
-                    description="Pasirinkite kategorijas, kurioms priklauso turinys"
+                    label="Temos"
+                    description="Pasirinkite temas, kurioms priklauso turinys"
                     items={categories.map(category => ({
                       id: category.id,
                       label: category.name,

--- a/lib/utils/form-validation.ts
+++ b/lib/utils/form-validation.ts
@@ -72,6 +72,6 @@ export const requiredMultipleSelection = (errorMessage?: string) =>
  *   description: descriptionSchema,
  *   slug: slugSchema,
  *   type: requiredSelection("Pasirinkite turinio tipą"),
- *   categories: requiredMultipleSelection("Pasirinkite bent vieną kategoriją"),
+ *   categories: requiredMultipleSelection("Pasirinkite bent vieną temą"),
  * })
  */ 


### PR DESCRIPTION
## Summary
- rename front-facing "Kategorijos" labels to "Temos"
- adjust forms, filters, and admin pages to match new terminology

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4264cff18832ab9550ac7469e45b4