### PR TITLE
Include specific audio extensions for attachments

### DIFF
--- a/components/content/file-attachments-uploader.tsx
+++ b/components/content/file-attachments-uploader.tsx
@@ -5,7 +5,8 @@ import { DocumentIcon, XMarkIcon, TrashIcon, ArrowDownTrayIcon } from '@heroicon
 import { cn } from '@/lib/utils'
 
 // Allow common document formats plus audio files
-const ACCEPTED_FILE_TYPES = '.pdf,.doc,.docx,.xls,.xlsx,.zip,audio/*'
+// Explicitly include common audio extensions to ensure browser support
+const ACCEPTED_FILE_TYPES = '.pdf,.doc,.docx,.xls,.xlsx,.zip,.mp3,.wav,audio/*'
 
 export type AttachmentFile = {
   id: string;

--- a/components/content/simplified-attachment-uploader.tsx
+++ b/components/content/simplified-attachment-uploader.tsx
@@ -4,7 +4,8 @@ import React, { useState } from 'react'
 import { DocumentIcon } from '@heroicons/react/24/solid'
 
 // Allow common document formats plus audio files
-const ACCEPTED_FILE_TYPES = '.pdf,.doc,.docx,.xls,.xlsx,.zip,audio/*'
+// Explicitly include common audio extensions to ensure browser support
+const ACCEPTED_FILE_TYPES = '.pdf,.doc,.docx,.xls,.xlsx,.zip,.mp3,.wav,audio/*'
 
 export type SimpleAttachment = {
   id: string;


### PR DESCRIPTION
## Summary
- ensure uploaders explicitly accept `.mp3` and `.wav` alongside generic audio types

## Testing
- `npm test`
- `npm run typecheck`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b81dcc6548832aaaac116adbdb30d4